### PR TITLE
Create default example tour for onboarding purposes

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": ["eg2.tslint"]
+}

--- a/example/.tours/exampletour.tour
+++ b/example/.tours/exampletour.tour
@@ -1,0 +1,15 @@
+{
+  "title": "Example Tour",
+  "steps": [
+    {
+      "file": "test.html",
+      "line": 4,
+      "description": "Step 1: Here is an example of how we specify the page title."
+    },
+    {
+      "file": "test.html",
+      "line": 6,
+      "description": "Step 2: Here is where we show an alert with string."
+    }
+  ]
+}

--- a/example/test.html
+++ b/example/test.html
@@ -1,0 +1,11 @@
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>JavaScript Hello World Example</title>
+		<script>
+			alert("Hello, World!");
+		</script>
+	</head>
+	<body>
+	</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codetour",
-  "version": "0.0.20",
+  "version": "0.0.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "icon": "images/icon.png",
   "engines": {
-    "vscode": "^1.40.0"
+    "vscode": "^1.44.0"
   },
   "categories": [
     "Other"
@@ -489,8 +489,11 @@
   },
   "devDependencies": {
     "@types/node": "^8.10.25",
+    "eslint": "^6.8.0",
+    "@typescript-eslint/parser": "^2.26.0",
+    "@typescript-eslint/eslint-plugin": "^2.26.0",
     "tslint": "^5.8.0",
-    "typescript": "^3.1.4",
+    "typescript": "^3.8.3",
     "vsce": "^1.75.0",
     "vscode": "^1.1.25"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,8 @@ import {
   endCurrentCodeTour,
   exportTour,
   promptForTour,
-  startCodeTour
+  startCodeTour,
+  startExampleTour
 } from "./store/actions";
 import { discoverTours } from "./store/provider";
 import { registerTreeProvider } from "./tree";
@@ -48,6 +49,7 @@ export async function activate(context: vscode.ExtensionContext) {
   registerFileSystemProvider();
   registerTextDocumentContentProvider();
   registerStatusBar();
+  startExampleTour(context.extensionPath);
 
   return {
     startTour: startCodeTour,

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import { commands, Memento, Uri, window, workspace } from "vscode";
 import { CodeTour, store } from ".";
 import { EXTENSION_NAME, FS_SCHEME, FS_SCHEME_CONTENT } from "../constants";
@@ -113,4 +114,10 @@ export async function exportTour(tour: CodeTour) {
   delete newTour.ref;
 
   return JSON.stringify(newTour, null, 2);
+}
+
+export function startExampleTour(extensionPath: string) {
+  const folderUrl = Uri.file(path.join(extensionPath, "example"));
+  commands.executeCommand("vscode.openFolder", folderUrl, true);
+  commands.executeCommand(`${EXTENSION_NAME}.startTour`);
 }


### PR DESCRIPTION
This is a basic onboarding feature so that devs first installing CodeTour can see how the tours work.