### PR TITLE
Fix invalid tour references

### DIFF
--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -27,7 +27,7 @@ let id = 0;
 
 const SHELL_SCRIPT_PATTERN = /^>>\s+(?<script>.*)$/gm;
 const COMMAND_PATTERN = /(?<commandPrefix>\(command:[\w+\.]+\?)(?<params>\[[^\]]+\])/gm;
-const TOUR_REFERENCE_PATTERN = /(?:\[(?<linkTitle>[^\]]+)\])?\[(?<tourTitle>[^\]#]+)?(?:#(?<stepNumber>\d+))?\](?!\()/gm;
+const TOUR_REFERENCE_PATTERN = /(?:\[(?<linkTitle>[^\]]+)\])?\[(?=[^\]])(?<tourTitle>[^\]#]+)?(?:#(?<stepNumber>\d+))?\](?!\()/gm;
 
 export class CodeTourComment implements Comment {
   public id: string = (++id).toString();

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -27,7 +27,7 @@ let id = 0;
 
 const SHELL_SCRIPT_PATTERN = /^>>\s+(?<script>.*)$/gm;
 const COMMAND_PATTERN = /(?<commandPrefix>\(command:[\w+\.]+\?)(?<params>\[[^\]]+\])/gm;
-const TOUR_REFERENCE_PATTERN = /(?:\[(?<linkTitle>[^\]]+)\])?\[(?=[^\]])(?<tourTitle>[^\]#]+)?(?:#(?<stepNumber>\d+))?\](?!\()/gm;
+const TOUR_REFERENCE_PATTERN = /(?:\[(?<linkTitle>[^\]]+)\])?\[(?=\s*[^\]\s])(?<tourTitle>[^\]#]+)?(?:#(?<stepNumber>\d+))?\](?!\()/gm;
 
 export class CodeTourComment implements Comment {
   public id: string = (++id).toString();

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -25,9 +25,9 @@ const CONTROLLER_LABEL = "CodeTour";
 
 let id = 0;
 
-const SHELL_SCRIPT_PATTERN = /^>>\s+(.*)$/gm;
-const COMMAND_PATTERN = /(\(command:[\w+\.]+\?)(\[[^\]]+\])/gm;
-const TOUR_REFERENCE_PATTERN = /(?:\[([^\]]+)\])?\[([^\]#]+)?(?:#(\d+))?\](?!\()/gm;
+const SHELL_SCRIPT_PATTERN = /^>>\s+(?<script>.*)$/gm;
+const COMMAND_PATTERN = /(?<commandPrefix>\(command:[\w+\.]+\?)(?<params>\[[^\]]+\])/gm;
+const TOUR_REFERENCE_PATTERN = /(?:\[(?<linkTitle>[^\]]+)\])?\[(?<tourTitle>[^\]#]+)?(?:#(?<stepNumber>\d+))?\](?!\()/gm;
 
 export class CodeTourComment implements Comment {
   public id: string = (++id).toString();


### PR DESCRIPTION
## Overview

This PR addresses (at least in part) the issue of the `TOUR_REFERENCE_PATTERN` regex identifying things like empty square brackets identified in #81.  It is not a full fix, as code-fences and inline code-statements are still processed, but it reduces the number of false-positives found by the regex.

## Description

The regex used to find tour references had the `linkTitle`, `tourTitle`, and `stepNumber` all as optional.  The replacement logic assumes that if `tourTitle` is missing, then at least `stepNumber` is present.  I updated the regex to ensure that the block including `tourTitle`/`stepNumber` is at least non-empty (and not just whitespace).  

## Testing
I used the following script to test various forms of valid and invalid links:

````
Here's a script:

```javascript
var test = [];
```
```typescript
String[] arr;
```


[Link][SomeTour#123]

[]

[linkTitle][]

[][tourTitle]

[][#1]

[linkTitle][#2]

[][tourTitle#3]
````
| **Before**| **After**|
|-----|-------|
| ![image](https://user-images.githubusercontent.com/9260413/97793722-2e592200-1bc6-11eb-9923-7b403a854019.png) | ![image](https://user-images.githubusercontent.com/9260413/97792705-f814a600-1bb7-11eb-8273-cf452aa1b703.png) |
