### PR TITLE
Remove Node.JS dependencies: TextEncoder, TextDecoder

### DIFF
--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { TextDecoder, TextEncoder } from "util";
 import * as vscode from "vscode";
 import { EXTENSION_NAME, SMALL_ICON_URL } from "../constants";
 import { CodeTour } from "../store";


### PR DESCRIPTION
Since [a while ago](https://github.com/nodejs/node/commit/932be0164f), the text encoding utils are globals in Node.JS.

cc @tanhakabir