### PR TITLE
Add new 'last-edit' tour versioning scheme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ In order to make it simpler to call common commands, CodeTour will prompt you wi
 
 When you record a tour, you'll be asked which git "ref" to associate it with. This allows you to define how resilient you want the tour to be, as changes are made to the respective codebase.
 
-<img width="600px" src="https://user-images.githubusercontent.com/116461/76692462-3f8ff700-6614-11ea-88a1-6fbded8e8507.png" />
+<img width="600px" src="https://user-images.githubusercontent.com/6195185/181656075-e90b479c-fbf0-45fb-a49d-65cb40b43320.png" />
 
 You can choose to associate with the tour with the following ref types:
 
@@ -183,6 +183,7 @@ You can choose to associate with the tour with the following ref types:
 - `Current Branch` - The tour is restricted to the current branch. This can have the same resiliency challenges as `None`, but, it allows you to maintain a special branch for your tours that can be versioned seperately. If the end-user has the associated branch checked out, then the tour will enable them to make edits to files as its taken. Otherwise, the tour will replay with read-only files.
 - `Current Commit` - The tour is restricted to the current commit, and therefore, will never get out of sync. If the end-user's `HEAD` points at the specified commit, then the tour will enable them to make edits to files as its taken. Otherwise, the tour will replay with read-only files.
 - Tags - The tour is restricted to the selected tag, and therefore, will never get out of sync. The repo's entire list of tags will be displayed, which allows you to easily select one.
+- `Last Commit that modified the tour` - The tour is restricted to the most recent commit that modified the tour file. If the end-user's `HEAD` points at the specified commit, then the tour will enable them to make edits to files as its taken. Otherwise, the tour will replay with read-only files. This allows you to bundle a code tour along with the changes that it's explaining into a single git commit.
 
 At any time, you can edit the tour's ref by right-clicking it in the `CodeTour` tree and selecting `Change Git Ref`. This let's you "rebase" a tour to a tag/commit as you change/update your code and/or codebase.
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -21,8 +21,25 @@ export interface RepositoryState {
   readonly refs: Ref[];
 }
 
+export interface LogOptions {
+  /** Max number of log entries to retrieve. If not specified, the default is 32. */
+  readonly maxEntries?: number;
+  readonly path?: string;
+}
+
+export interface Commit {
+  readonly hash: string;
+  readonly message: string;
+  readonly parents: string[];
+  readonly authorDate?: Date;
+  readonly authorName?: string;
+  readonly authorEmail?: string;
+  readonly commitDate?: Date;
+}
+
 export interface Repository {
   readonly state: RepositoryState;
+  log(options?: LogOptions): Promise<Commit[]>;
 }
 
 interface GitAPI {

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -21,7 +21,7 @@ class CodeTourNotebookProvider implements vscode.NotebookSerializer {
     let steps: any[] = [];
 
     for (let item of tour.steps) {
-      const uri = await getStepFileUri(item, workspaceRoot, tour.ref);
+      const uri = await getStepFileUri(item, workspaceRoot, tour);
       const document = await vscode.workspace.openTextDocument(uri);
 
       const startLine = item.line! > 10 ? item.line! - 10 : 0;

--- a/src/player/index.ts
+++ b/src/player/index.ts
@@ -242,7 +242,7 @@ async function renderCurrentStep() {
   }
 
   const workspaceRoot = store.activeTour?.workspaceRoot;
-  const uri = await getStepFileUri(step, workspaceRoot, currentTour.ref);
+  const uri = await getStepFileUri(step, workspaceRoot, currentTour);
 
   let line = step.line
     ? step.line - 1

--- a/src/recorder/commands.ts
+++ b/src/recorder/commands.ts
@@ -872,6 +872,13 @@ export function registerRecorderCommands() {
         description: "Keep the tour associated with a specific commit",
         ref: repository.state.HEAD ? repository.state.HEAD.commit! : "",
         alwaysShow: true
+      },
+      {
+        label: "$(git-commit) Last commit that modified the tour",
+        description:
+          "Keep the tour associated with the most recent commit that modified the tour",
+        ref: "last-edit",
+        alwaysShow: true
       }
     ];
 

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -220,7 +220,7 @@ export async function exportTour(tour: CodeTour) {
       }
 
       const workspaceRoot = getWorkspaceUri(tour);
-      const stepFileUri = await getStepFileUri(step, workspaceRoot, tour.ref);
+      const stepFileUri = await getStepFileUri(step, workspaceRoot, tour);
       const contents = await readUriContents(stepFileUri);
 
       delete step.markerTitle;


### PR DESCRIPTION
The Current Commit versioning strategy for tours is quite brittle, because it is
based on commit hashes. The moment history gets rewritten by a rebase, the tour
becomes untethered from the commit that we are trying to attach it to, because
the commit hash that's recorded in the tour file no longer exists.

Also, the Current Commit versioning strategy means that a tour commit must be in a
separate commit, becuase the commit that it's attached to must already exist so
that its hash can be recorded in the `ref` field of the tour.

Introduce a 'last-edit' versioning scheme. If the value of the ref is
`'last-edit'`, then the tour is associated with the most recent commit that
modifies the tour file.

This will enable a code change and a tour which documents the code change to
exist in the same commit. If during code review, the git history is rewritten by
a rebase, the tour will still properly be associated with the correct commit.
This should provide a far more robust and simpler user experience than the
Current Commit versioning strategy.