### PR TITLE
fix mac pattern recording

### DIFF
--- a/src/recorder/commands.ts
+++ b/src/recorder/commands.ts
@@ -387,13 +387,16 @@ export function registerRecorderCommands() {
         .get("recordMode");
 
       if (mode === "pattern") {
-        const contents = vscode.window.activeTextEditor?.document
-          .lineAt(thread.range.start)
+        const fileEditors = vscode.window.visibleTextEditors.filter(
+          editor => editor.document && editor.document.uri.scheme === "file"
+        );
+        const contents = fileEditors?.[0]?.document
+          .lineAt(thread.range.start.line)
           .text.trim();
 
         const pattern =
           "^[^\\S\\n]*" + contents!.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const match = vscode.window.activeTextEditor?.document
+        const match = fileEditors?.[0]?.document
           .getText()
           .match(new RegExp(pattern, "gm"));
 
@@ -654,7 +657,7 @@ export function registerRecorderCommands() {
         prompt: `Enter the title for this tour step`,
         value: step.title || ""
       });
-      
+
       if (typeof response === "undefined") {
         return;
       } else if (response) {
@@ -662,11 +665,11 @@ export function registerRecorderCommands() {
       } else {
         delete step.title;
       }
-      
+
       saveTour(node.tour);
     }
   );
-  
+
   vscode.commands.registerCommand(
     `${EXTENSION_NAME}.changeTourStepIcon`,
     async (node: CodeTourStepNode) => {
@@ -675,7 +678,7 @@ export function registerRecorderCommands() {
         prompt: `Enter the icon for this tour step`,
         value: step.icon || ""
       });
-      
+
       if (typeof response === "undefined") {
         return;
       } else if (response) {


### PR DESCRIPTION
The issue has to do with accessing vscode.window.activeTextEditor?.document

Probably something changed in vscode since that part was written and activeTextEditor returns the codeTour textbox that the comment is being written. Therefore, this crashes for any file where we try to access a line number bigger than the few lines the textbox has.

This PR gets one way to access the right editor